### PR TITLE
Add travis badge [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OncoTracer
+# OncoTracer [![Build Status](https://travis-ci.org/hms-dbmi/OncoTracer.svg?branch=master)](https://travis-ci.org/hms-dbmi/OncoTracer)
 OncoTracer longitudinal cancer genomics visualization project.
 
 To run OncoTracer from its source code simply run the following:


### PR DESCRIPTION
Note the `[skip ci]` won't trigger a travis build. Useful for ReadMe changes etc.